### PR TITLE
chore: add cache to gradle dependencies 

### DIFF
--- a/.github/workflows/android ci.yml
+++ b/.github/workflows/android ci.yml
@@ -1,6 +1,7 @@
 name: Android CI
 
-on: [push, pull_request]
+on: 
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/android ci.yml
+++ b/.github/workflows/android ci.yml
@@ -9,6 +9,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-        
   
       - name: Set up JDK
         uses: actions/setup-java@v3


### PR DESCRIPTION
This will enhance pipeline efficiency by reducing time to download dependencies each time run the pipeline. 

it took [59s](https://github.com/MahmoudMabrok/QuranyApp/actions/runs/11540427374/job/32121243894#step:5:46) before cache 
it tooks [18s](https://github.com/MahmoudMabrok/QuranyApp/actions/runs/11540470218/job/32121332852?pr=103#step:5:44) after cache 